### PR TITLE
Prevent Git commit failures by skipping pre-commit hooks

### DIFF
--- a/buildmanager.drush.inc
+++ b/buildmanager.drush.inc
@@ -490,7 +490,7 @@ function _buildmanager_commit($message) {
     return '';
   }
   // Add any new files added to the repo.
-  $command = "git add . ; git commit -am '{$message}';";
+  $command = "git add . ; git commit -am '{$message}' --no-verify;";
   return $command;
 }
 


### PR DESCRIPTION
If a user has Git pre-commit hooks installed in their repo, they can cause a `drush buildmanager` operation to appear to stall and ultimate fail. Skipping pre-commit hooks prevents this from happening.
