### PR TITLE
Undefined index notice in array_merge_recursive_distinct()

### DIFF
--- a/buildmanager.drush.inc
+++ b/buildmanager.drush.inc
@@ -483,7 +483,7 @@ function &array_merge_recursive_distinct(array &$array1, &$array2 = NULL) {
   if (is_array($array2)) {
     foreach ($array2 as $key => $val) {
       if (isset($array2[$key]) && is_array($array2[$key])) {
-        $merged[$key] = is_array($merged[$key]) ? array_merge_recursive_distinct($merged[$key], $array2[$key]) : $array2[$key];
+        $merged[$key] = (isset($merged[$key]) && is_array($merged[$key])) ? array_merge_recursive_distinct($merged[$key], $array2[$key]) : $array2[$key];
       }
       else {
         $merged[$key] = $val;


### PR DESCRIPTION
`array_merge_recursive_distinct()` causes an undefined index notice, resulting in dozens of lines like the following every time I run `buildmanager-build`:

```
Undefined index: views buildmanager.drush.inc:486 [2.26 sec, 8.49MB] [notice]
```

I'm pretty sure the following is the fix. It eliminates the notices, and it shouldn't affect behavior.
